### PR TITLE
[Feature] 템플릿 조회 페이지 구현 & 마이페이지 미리보기 적용

### DIFF
--- a/card-capture/src/app/templates/[templateId]/TemplatesContent.tsx
+++ b/card-capture/src/app/templates/[templateId]/TemplatesContent.tsx
@@ -7,6 +7,7 @@ import { useQuery } from '@tanstack/react-query';
 import { Template } from '@/types';
 import { templateApi } from '@/api';
 import TemplateImage from '@/components/templates/TemplateImage/TemplateImage';
+import TemplatePrompt from '@/components/templates/TemplatePrompt/TemplatePrompt';
 
 const TemplatesContent = () => {
   /**
@@ -21,10 +22,11 @@ const TemplatesContent = () => {
   });
 
   return (
-    <div className="h-screen w-screen overflow-y-scroll font-Pretendard">
+    <div className="w-screen overflow-y-scroll font-Pretendard">
       <NavigationBar isTransparent={false} />
-      <div className="flex h-full flex-col items-center justify-center pt-[60px]">
+      <div className="flex h-full flex-col items-center justify-center gap-10 pt-[60px]">
         <TemplateImage data={data} />
+        <TemplatePrompt prompt={data?.prompt} />
       </div>
     </div>
   );

--- a/card-capture/src/app/templates/[templateId]/TemplatesContent.tsx
+++ b/card-capture/src/app/templates/[templateId]/TemplatesContent.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import NavigationBar from '@/components/common/NavigationBar/NavigationBar';
+import React from 'react';
+import { useParams } from 'next/navigation';
+import { useQuery } from '@tanstack/react-query';
+import { Template } from '@/types';
+import { templateApi } from '@/api';
+import TemplateImage from '@/components/templates/TemplateImage/TemplateImage';
+
+const TemplatesContent = () => {
+  /**
+   * 라우팅된 아이디 기반으로 템플릿 데이터 가져오기
+   */
+  const params = useParams();
+  const id = params.templateId as string;
+
+  const { data } = useQuery<Template>({
+    queryKey: [`template-${id}`],
+    queryFn: () => templateApi.getTemplateData(Number(id)),
+  });
+
+  return (
+    <div className="h-screen w-screen overflow-y-scroll font-Pretendard">
+      <NavigationBar isTransparent={false} />
+      <div className="flex h-full flex-col items-center justify-center pt-[60px]">
+        <TemplateImage data={data} />
+      </div>
+    </div>
+  );
+};
+
+export default TemplatesContent;

--- a/card-capture/src/app/templates/[templateId]/page.tsx
+++ b/card-capture/src/app/templates/[templateId]/page.tsx
@@ -1,0 +1,10 @@
+import dynamic from 'next/dynamic';
+
+const TemplatesPage = dynamic(() => import('./TemplatesContent'), {
+  ssr: false,
+  loading: () => <p></p>,
+});
+
+export default function Page() {
+  return <TemplatesPage />;
+}

--- a/card-capture/src/components/common/Poster/Poster.tsx
+++ b/card-capture/src/components/common/Poster/Poster.tsx
@@ -10,16 +10,19 @@ type PosterProps = {
   size: number;
   card: Card | undefined;
   isSelected?: boolean;
+  hasBorder?: boolean;
 };
 
-const Poster = forwardRef<HTMLDivElement, PosterProps>(({ size, card, isSelected }, ref) => {
+const Poster = forwardRef<HTMLDivElement, PosterProps>(({ size, card, isSelected, hasBorder = true }, ref) => {
   if (!card) return <div></div>;
 
   const background = card.background;
   const scaleRatio = size / 550;
 
   return (
-    <div className={`border-[2.5px] ${isSelected ? 'border-main' : 'border-transparent'}`}>
+    <div
+      className={`border-[2.5px] ${isSelected ? 'border-main' : 'border-transparent'} ${hasBorder ? '' : 'border-none'}`}
+    >
       <div
         ref={ref}
         className={`relative overflow-hidden bg-white`}

--- a/card-capture/src/components/main/TemplateGallery/components/TemplateList/TemplateList.tsx
+++ b/card-capture/src/components/main/TemplateGallery/components/TemplateList/TemplateList.tsx
@@ -1,5 +1,4 @@
 import { DummyTemplateType } from '@/components/main/TemplateGallery/data/templateData';
-import Image from 'next/image';
 
 type TemplateListType = {
   templateData: DummyTemplateType[];

--- a/card-capture/src/components/mypage/UserTemplates/components/UserTemplateDetails.tsx
+++ b/card-capture/src/components/mypage/UserTemplates/components/UserTemplateDetails.tsx
@@ -3,22 +3,31 @@ import HeartIcon from '@/components/common/Icon/HeartIcon';
 import CheckIcon from '@/components/common/Icon/CheckIcon';
 import { Template } from '@/types';
 import { useRouter } from 'next/navigation';
-import { useCardsStore } from '@/store/useCardsStore';
-import { jsonUtils } from '@/utils';
 import useAmplitudeContext from '@/hooks/useAmplitudeContext';
+import Poster from '@/components/common/Poster/Poster';
+import useParseTemplateData from '@/hooks/useParseTemplateData';
+import useIsMobile from '@/hooks/useIsMobile';
+import { useEffect, useState } from 'react';
 
 type UserTemplateDetailsProps = {
   template: Template;
 };
 
 const UserTemplateDetails = ({ template }: UserTemplateDetailsProps) => {
-  const setCards = useCardsStore(state => state.setCard);
-  const setTemplateId = useCardsStore(state => state.setTemplateId);
   const router = useRouter();
 
   const moveToEditorHandler = () => {
     router.push(`/editor/${template.id}`);
   };
+
+  const templateData = useParseTemplateData(template.editor);
+  const [templateSize, setTemplateSize] = useState<number>(270);
+  const { isMobile } = useIsMobile();
+
+  useEffect(() => {
+    if (isMobile) setTemplateSize(240);
+    else setTemplateSize(260);
+  }, [isMobile]);
 
   /**
    * 마이페이지에서 버튼 클릭에 대한 tracking
@@ -27,28 +36,34 @@ const UserTemplateDetails = ({ template }: UserTemplateDetailsProps) => {
 
   return (
     <div className="flex w-fit flex-col gap-2 rounded-[20px] border border-border p-4">
-      <div className="h-[250px] w-[250px] rounded-[20px] bg-gray8 md:h-[270px] md:w-[270px]"></div>
+      <div className="h-fit w-fit overflow-hidden rounded-[20px] border border-border bg-border">
+        {templateData ? (
+          <Poster size={templateSize} card={templateData[0]} hasBorder={false} />
+        ) : (
+          <div style={{ width: `${templateSize}px`, height: `${templateSize}px` }}></div>
+        )}
+      </div>
 
       <div className="flex flex-col gap-1 px-1">
         <div className="flex flex-row justify-between">
-          <p className="text-[16px] font-semibold">
+          <p className="text-[15px] font-semibold">
             {template.title.slice(0, 13)} {template.title.length >= 13 && '...'}
           </p>
 
           <div className="flex flex-row gap-2">
             <div className="flex flex-row items-center justify-end gap-1">
-              <HeartIcon width={20} className="text-heart" />
+              <HeartIcon width={18} className="text-heart" />
               <p className="text-xs text-gray5">{template.likes}</p>
             </div>
             <div className="flex flex-row items-center justify-end gap-1">
-              <CheckIcon width={20} className="text-blue-500" />
+              <CheckIcon width={18} className="text-blue-500" />
               <p className="text-xs text-gray5">{template.purchaseCount}</p>
             </div>
           </div>
         </div>
 
-        <p className="text-[14px] text-gray2">{template.description}</p>
-        <div className="flex flex-row gap-2 text-xs text-gray5">
+        <p className="text-[13px] text-gray2">{template.description}</p>
+        <div className="flex flex-row gap-2 text-[12px] text-gray5">
           {template.templateTags.map(({ korean, english }) => (
             <p key={english}>#{korean}</p>
           ))}
@@ -59,10 +74,10 @@ const UserTemplateDetails = ({ template }: UserTemplateDetailsProps) => {
               trackAmplitudeEvent('mypage-goToEditor-click');
               moveToEditorHandler();
             }}
-            className="w-full rounded-md py-2 text-[13px]"
+            className="w-full rounded-lg py-2 text-[12px]"
             type="full"
           >
-            에디터로 이동
+            <p className="font-medium">에디터로 이동</p>
           </Button>
         </div>
       </div>

--- a/card-capture/src/components/templates/TemplateImage/TemplateImage.tsx
+++ b/card-capture/src/components/templates/TemplateImage/TemplateImage.tsx
@@ -3,6 +3,8 @@ import { useEffect, useState } from 'react';
 import Poster from '@/components/common/Poster/Poster';
 import { jsonUtils } from '@/utils';
 import { Card } from '@/store/useCardsStore/type';
+import Button from '@/components/common/Button/Button';
+import HeartIcon from '@/components/common/Icon/HeartIcon';
 
 type TemplateImageProps = {
   data?: Template;
@@ -10,6 +12,7 @@ type TemplateImageProps = {
 
 const TemplateImage = ({ data }: TemplateImageProps) => {
   if (!data) return <></>;
+  const { title, description, fileUrl, editor, likes, templateTags } = data;
 
   const [isValidImage, setIsValidImage] = useState<boolean>(false);
 
@@ -17,20 +20,33 @@ const TemplateImage = ({ data }: TemplateImageProps) => {
    * 유효한 이미지 url인지 확인하는 로직
    */
   useEffect(() => {
-    if (!data.fileUrl) return;
+    if (!fileUrl) return;
 
     const img = new window.Image();
     img.onload = () => setIsValidImage(true);
     img.onerror = () => setIsValidImage(false);
-    img.src = data.fileUrl;
-  }, [data.fileUrl]);
+    img.src = fileUrl;
+  }, [fileUrl]);
 
   const [templateData, setTemplateData] = useState<Card[]>([]);
 
   useEffect(() => {
-    const parsedData = jsonUtils.parseEscapedJson(data.editor);
+    const parsedData = jsonUtils.parseEscapedJson(editor);
     setTemplateData(parsedData);
-  }, [data.editor]);
+  }, [editor]);
+
+  const [tags, setTags] = useState<string[]>([]);
+
+  useEffect(() => {
+    const tagList: string[] = [];
+
+    templateTags.forEach(({ english, korean }) => {
+      if (english.length) tagList.push(english);
+      if (korean.length) tagList.push(korean);
+    });
+
+    setTags(tagList);
+  }, [templateTags]);
 
   return (
     <div className="flex w-[950px] flex-row justify-between">
@@ -40,8 +56,27 @@ const TemplateImage = ({ data }: TemplateImageProps) => {
       {/*  <Poster size={500} card={templateData[0]} />*/}
       {/*)}*/}
       <Poster size={450} card={templateData[0]} />
-      <div className="flex w-[450px] flex-col justify-start">
-        <div className="flex flex-row items-center justify-end"></div>
+      <div className="flex w-[450px] flex-col justify-start gap-7 p-5">
+        <div className="flex flex-col border-b border-border pb-7">
+          <div className="flex flex-row items-center justify-end gap-1">
+            <HeartIcon width={15} className="text-heart" />
+            <p className="text-[13px] font-medium">{likes}</p>
+          </div>
+          <p className="text-[25px] font-semibold">{title}</p>
+          <p className="pt-2 text-[14px] text-gray2">{description}</p>
+        </div>
+
+        <div className="flex-1 flex-col">
+          <div className="flex flex-row flex-wrap gap-1">
+            {tags.map(tag => (
+              <p className="w-fit rounded-full border border-border px-3 py-1 text-[13px] text-gray2">#{tag}</p>
+            ))}
+          </div>
+        </div>
+
+        <Button type="full" className="w-full rounded-[30px] py-3 shadow-default" shadow={true}>
+          <p className="text-[14px] font-medium">구매하기</p>
+        </Button>
       </div>
     </div>
   );

--- a/card-capture/src/components/templates/TemplateImage/TemplateImage.tsx
+++ b/card-capture/src/components/templates/TemplateImage/TemplateImage.tsx
@@ -4,6 +4,7 @@ import Poster from '@/components/common/Poster/Poster';
 import Button from '@/components/common/Button/Button';
 import HeartIcon from '@/components/common/Icon/HeartIcon';
 import useParseTemplateData from '@/hooks/useParseTemplateData';
+import useIsMobile from '@/hooks/useIsMobile';
 
 type TemplateImageProps = {
   data?: Template;
@@ -42,28 +43,38 @@ const TemplateImage = ({ data }: TemplateImageProps) => {
     setTags(tagList);
   }, [templateTags]);
 
+  const { isMobile, windowWidth } = useIsMobile(768);
+  const [templateSize, setTemplateSize] = useState(450);
+
+  useEffect(() => {
+    if (windowWidth < 640) setTemplateSize(300);
+    else if (windowWidth < 768) setTemplateSize(350);
+    else if (windowWidth < 1024) setTemplateSize(370);
+    else setTemplateSize(450);
+  }, [windowWidth]);
+
   return (
-    <div className="flex flex-row justify-between py-10 sm:w-[700px] md:w-[950px]">
+    <div className="flex w-[750px] flex-col items-center justify-between py-10 md:w-[800px] md:flex-row md:items-stretch md:gap-10 lg:w-[950px]">
       {/*{isValidImage ? (*/}
       {/*  <Image src={data.fileUrl} alt="templateImage" width={500} height={500} />*/}
       {/*) : (*/}
       {/*  <Poster size={500} card={templateData[0]} />*/}
       {/*)}*/}
-      <div className="overflow-hidden rounded-[30px]">
-        <Poster size={450} card={templateData[0]} />
+      <div className="overflow-hidden rounded-[25px]">
+        <Poster size={templateSize} card={templateData[0]} hasBorder={false} />
       </div>
 
-      <div className="flex w-[450px] flex-col justify-start gap-7 p-5">
+      <div className="flex flex-1 flex-col justify-start gap-7 p-5">
         <div className="flex flex-col border-b border-border pb-7">
           <div className="flex flex-row items-center justify-end gap-1">
             <HeartIcon width={15} className="text-heart" />
             <p className="text-[13px] font-medium">{likes}</p>
           </div>
-          <p className="text-[25px] font-semibold">{title}</p>
-          <p className="pt-2 text-[14px] text-gray2">{description}</p>
+          <p className="text-[18px] font-semibold md:text-[20px] lg:text-[25px]">{title}</p>
+          <p className="pt-2 text-[12px] text-gray2 md:text-[13px] lg:text-[14px]">{description}</p>
         </div>
 
-        <div className="flex-1 flex-col">
+        <div className={`${isMobile ? `w-[${templateSize}px]` : ''} flex-col md:flex-1`}>
           <div className="flex flex-row flex-wrap gap-1">
             {tags.map(tag => (
               <p className="w-fit rounded-full border border-border px-3 py-1 text-[13px] text-gray2">#{tag}</p>

--- a/card-capture/src/components/templates/TemplateImage/TemplateImage.tsx
+++ b/card-capture/src/components/templates/TemplateImage/TemplateImage.tsx
@@ -1,10 +1,9 @@
 import { Template } from '@/types';
 import { useEffect, useState } from 'react';
 import Poster from '@/components/common/Poster/Poster';
-import { jsonUtils } from '@/utils';
-import { Card } from '@/store/useCardsStore/type';
 import Button from '@/components/common/Button/Button';
 import HeartIcon from '@/components/common/Icon/HeartIcon';
+import useParseTemplateData from '@/hooks/useParseTemplateData';
 
 type TemplateImageProps = {
   data?: Template;
@@ -44,7 +43,7 @@ const TemplateImage = ({ data }: TemplateImageProps) => {
   }, [templateTags]);
 
   return (
-    <div className="flex w-[950px] flex-row justify-between py-10">
+    <div className="flex flex-row justify-between py-10 sm:w-[700px] md:w-[950px]">
       {/*{isValidImage ? (*/}
       {/*  <Image src={data.fileUrl} alt="templateImage" width={500} height={500} />*/}
       {/*) : (*/}

--- a/card-capture/src/components/templates/TemplateImage/TemplateImage.tsx
+++ b/card-capture/src/components/templates/TemplateImage/TemplateImage.tsx
@@ -28,12 +28,7 @@ const TemplateImage = ({ data }: TemplateImageProps) => {
     img.src = fileUrl;
   }, [fileUrl]);
 
-  const [templateData, setTemplateData] = useState<Card[]>([]);
-
-  useEffect(() => {
-    const parsedData = jsonUtils.parseEscapedJson(editor);
-    setTemplateData(parsedData);
-  }, [editor]);
+  const templateData = useParseTemplateData(editor);
 
   const [tags, setTags] = useState<string[]>([]);
 

--- a/card-capture/src/components/templates/TemplateImage/TemplateImage.tsx
+++ b/card-capture/src/components/templates/TemplateImage/TemplateImage.tsx
@@ -49,13 +49,16 @@ const TemplateImage = ({ data }: TemplateImageProps) => {
   }, [templateTags]);
 
   return (
-    <div className="flex w-[950px] flex-row justify-between">
+    <div className="flex w-[950px] flex-row justify-between py-10">
       {/*{isValidImage ? (*/}
       {/*  <Image src={data.fileUrl} alt="templateImage" width={500} height={500} />*/}
       {/*) : (*/}
       {/*  <Poster size={500} card={templateData[0]} />*/}
       {/*)}*/}
-      <Poster size={450} card={templateData[0]} />
+      <div className="overflow-hidden rounded-[30px]">
+        <Poster size={450} card={templateData[0]} />
+      </div>
+
       <div className="flex w-[450px] flex-col justify-start gap-7 p-5">
         <div className="flex flex-col border-b border-border pb-7">
           <div className="flex flex-row items-center justify-end gap-1">

--- a/card-capture/src/components/templates/TemplateImage/TemplateImage.tsx
+++ b/card-capture/src/components/templates/TemplateImage/TemplateImage.tsx
@@ -60,7 +60,7 @@ const TemplateImage = ({ data }: TemplateImageProps) => {
       {/*) : (*/}
       {/*  <Poster size={500} card={templateData[0]} />*/}
       {/*)}*/}
-      <div className="overflow-hidden rounded-[25px]">
+      <div className="overflow-hidden rounded-[25px] border border-border">
         <Poster size={templateSize} card={templateData[0]} hasBorder={false} />
       </div>
 

--- a/card-capture/src/components/templates/TemplateImage/TemplateImage.tsx
+++ b/card-capture/src/components/templates/TemplateImage/TemplateImage.tsx
@@ -1,0 +1,50 @@
+import { Template } from '@/types';
+import { useEffect, useState } from 'react';
+import Poster from '@/components/common/Poster/Poster';
+import { jsonUtils } from '@/utils';
+import { Card } from '@/store/useCardsStore/type';
+
+type TemplateImageProps = {
+  data?: Template;
+};
+
+const TemplateImage = ({ data }: TemplateImageProps) => {
+  if (!data) return <></>;
+
+  const [isValidImage, setIsValidImage] = useState<boolean>(false);
+
+  /**
+   * 유효한 이미지 url인지 확인하는 로직
+   */
+  useEffect(() => {
+    if (!data.fileUrl) return;
+
+    const img = new window.Image();
+    img.onload = () => setIsValidImage(true);
+    img.onerror = () => setIsValidImage(false);
+    img.src = data.fileUrl;
+  }, [data.fileUrl]);
+
+  const [templateData, setTemplateData] = useState<Card[]>([]);
+
+  useEffect(() => {
+    const parsedData = jsonUtils.parseEscapedJson(data.editor);
+    setTemplateData(parsedData);
+  }, [data.editor]);
+
+  return (
+    <div className="flex w-[950px] flex-row justify-between">
+      {/*{isValidImage ? (*/}
+      {/*  <Image src={data.fileUrl} alt="templateImage" width={500} height={500} />*/}
+      {/*) : (*/}
+      {/*  <Poster size={500} card={templateData[0]} />*/}
+      {/*)}*/}
+      <Poster size={450} card={templateData[0]} />
+      <div className="flex w-[450px] flex-col justify-start">
+        <div className="flex flex-row items-center justify-end"></div>
+      </div>
+    </div>
+  );
+};
+
+export default TemplateImage;

--- a/card-capture/src/components/templates/TemplatePrompt/TemplatePrompt.tsx
+++ b/card-capture/src/components/templates/TemplatePrompt/TemplatePrompt.tsx
@@ -1,5 +1,6 @@
 import { Prompt } from '@/types';
 import PromptTitleText from '@/components/prompt/PromptInput/components/common/PromptTitleText';
+import PromptCategoryText from '@/components/prompt/PromptInput/components/common/PromptCategoryText';
 
 type TemplatePromptProps = {
   prompt?: Prompt;
@@ -9,10 +10,11 @@ const TemplatePrompt = ({ prompt }: TemplatePromptProps) => {
   if (!prompt) return <></>;
 
   return (
-    <div className="mb-10 flex w-[900px] flex-col justify-between gap-7 rounded-[30px] border border-border p-[50px]">
+    <div className="mb-10 flex w-[900px] flex-col justify-between gap-7 rounded-[30px] border border-border p-[50px] shadow-default">
       <p className="text-[22px] font-semibold">입력된 프롬프트</p>
-      <div className="flex flex-col gap-7">
+      <div className="flex flex-col gap-7 px-1">
         <div className="flex flex-col gap-[7px]">
+          <PromptCategoryText>1. 문구</PromptCategoryText>
           <PromptTitleText>카드뉴스에 작성할 문구를 입력해주세요</PromptTitleText>
           {prompt.phraseDetails.phrases.map(str => (
             <p className="w-full rounded-[10px] border border-border px-[15px] py-[12px] text-[13px] text-gray2 outline-none">
@@ -21,12 +23,14 @@ const TemplatePrompt = ({ prompt }: TemplatePromptProps) => {
           ))}
         </div>
         <div className="flex flex-col gap-[7px]">
+          <PromptCategoryText>2. 목적</PromptCategoryText>
           <PromptTitleText>제작 목적을 입력해주세요</PromptTitleText>
           <p className="w-full rounded-[10px] border border-border px-[15px] py-[12px] text-[13px] text-gray2 outline-none">
             {prompt.purpose}
           </p>
         </div>
         <div className="flex flex-col gap-[10px]">
+          <PromptCategoryText>3. 색상</PromptCategoryText>
           <PromptTitleText>색상을 선택해주세요</PromptTitleText>
           <div className="flex flex-row items-center gap-[10px]">
             <div
@@ -35,6 +39,18 @@ const TemplatePrompt = ({ prompt }: TemplatePromptProps) => {
             />
             <p className="text-[13px] tracking-little-tight">{prompt.color}</p>
           </div>
+        </div>
+        <div className="flex flex-col gap-[10px]">
+          <PromptCategoryText>4. 모델</PromptCategoryText>
+          <PromptTitleText>이미지 모델을 선택해주세요</PromptTitleText>
+          <p className="w-full rounded-[10px] border border-border px-[15px] py-[12px] text-[13px] text-gray2 outline-none">
+            {prompt.model === 'DALL_E_3' && (
+              <div className="flex flex-row gap-4">
+                <p className="text-[14px] font-semibold text-defaultBlack">Dalle 3</p>
+                <p>'고해상도, 창의적이고 귀여운 카드 포스터 적합 이미지를 생성합니다!'</p>
+              </div>
+            )}
+          </p>
         </div>
       </div>
     </div>

--- a/card-capture/src/components/templates/TemplatePrompt/TemplatePrompt.tsx
+++ b/card-capture/src/components/templates/TemplatePrompt/TemplatePrompt.tsx
@@ -1,0 +1,44 @@
+import { Prompt } from '@/types';
+import PromptTitleText from '@/components/prompt/PromptInput/components/common/PromptTitleText';
+
+type TemplatePromptProps = {
+  prompt?: Prompt;
+};
+
+const TemplatePrompt = ({ prompt }: TemplatePromptProps) => {
+  if (!prompt) return <></>;
+
+  return (
+    <div className="mb-10 flex w-[900px] flex-col justify-between gap-7 rounded-[30px] border border-border p-[50px]">
+      <p className="text-[22px] font-semibold">입력된 프롬프트</p>
+      <div className="flex flex-col gap-7">
+        <div className="flex flex-col gap-[7px]">
+          <PromptTitleText>카드뉴스에 작성할 문구를 입력해주세요</PromptTitleText>
+          {prompt.phraseDetails.phrases.map(str => (
+            <p className="w-full rounded-[10px] border border-border px-[15px] py-[12px] text-[13px] text-gray2 outline-none">
+              {str}
+            </p>
+          ))}
+        </div>
+        <div className="flex flex-col gap-[7px]">
+          <PromptTitleText>제작 목적을 입력해주세요</PromptTitleText>
+          <p className="w-full rounded-[10px] border border-border px-[15px] py-[12px] text-[13px] text-gray2 outline-none">
+            {prompt.purpose}
+          </p>
+        </div>
+        <div className="flex flex-col gap-[10px]">
+          <PromptTitleText>색상을 선택해주세요</PromptTitleText>
+          <div className="flex flex-row items-center gap-[10px]">
+            <div
+              className="h-[30px] w-[30px] rounded-[8px] border-2 border-border"
+              style={{ backgroundColor: `${prompt.color}` }}
+            />
+            <p className="text-[13px] tracking-little-tight">{prompt.color}</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default TemplatePrompt;

--- a/card-capture/src/components/templates/TemplatePrompt/TemplatePrompt.tsx
+++ b/card-capture/src/components/templates/TemplatePrompt/TemplatePrompt.tsx
@@ -10,14 +10,14 @@ const TemplatePrompt = ({ prompt }: TemplatePromptProps) => {
   if (!prompt) return <></>;
 
   return (
-    <div className="mb-10 flex w-[900px] flex-col justify-between gap-7 rounded-[30px] border border-border p-[50px] shadow-default">
-      <p className="text-[22px] font-semibold">입력된 프롬프트</p>
+    <div className="flex w-full flex-col justify-between gap-7 border-border bg-itembg p-7 sm:mb-10 sm:w-[650px] sm:rounded-[30px] sm:border sm:bg-white sm:p-10 sm:shadow-default md:w-[780px] md:p-[50px] lg:w-[900px]">
+      <p className="text-[18px] font-semibold md:text-[22px]">입력된 프롬프트</p>
       <div className="flex flex-col gap-7 px-1">
         <div className="flex flex-col gap-[7px]">
           <PromptCategoryText>1. 문구</PromptCategoryText>
           <PromptTitleText>카드뉴스에 작성할 문구를 입력해주세요</PromptTitleText>
           {prompt.phraseDetails.phrases.map(str => (
-            <p className="w-full rounded-[10px] border border-border px-[15px] py-[12px] text-[13px] text-gray2 outline-none">
+            <p className="w-full rounded-[10px] border border-border bg-white px-[15px] py-[12px] text-[13px] text-gray2 outline-none">
               {str}
             </p>
           ))}
@@ -25,7 +25,7 @@ const TemplatePrompt = ({ prompt }: TemplatePromptProps) => {
         <div className="flex flex-col gap-[7px]">
           <PromptCategoryText>2. 목적</PromptCategoryText>
           <PromptTitleText>제작 목적을 입력해주세요</PromptTitleText>
-          <p className="w-full rounded-[10px] border border-border px-[15px] py-[12px] text-[13px] text-gray2 outline-none">
+          <p className="w-full rounded-[10px] border border-border bg-white px-[15px] py-[12px] text-[13px] text-gray2 outline-none">
             {prompt.purpose}
           </p>
         </div>
@@ -43,11 +43,14 @@ const TemplatePrompt = ({ prompt }: TemplatePromptProps) => {
         <div className="flex flex-col gap-[10px]">
           <PromptCategoryText>4. 모델</PromptCategoryText>
           <PromptTitleText>이미지 모델을 선택해주세요</PromptTitleText>
-          <p className="w-full rounded-[10px] border border-border px-[15px] py-[12px] text-[13px] text-gray2 outline-none">
+          <p className="flex w-full items-center rounded-[10px] border border-border bg-white px-[15px] py-[12px] text-gray2 outline-none">
             {prompt.model === 'DALL_E_3' && (
               <div className="flex flex-row gap-4">
-                <p className="text-[14px] font-semibold text-defaultBlack">Dalle 3</p>
-                <p>'고해상도, 창의적이고 귀여운 카드 포스터 적합 이미지를 생성합니다!'</p>
+                <p className="whitespace-nowrap text-[12px] font-semibold text-defaultBlack md:text-[14px]">Dalle 3</p>
+                <p className="text-[12px] md:text-[13px]">
+                  {' '}
+                  '고해상도, 창의적이고 귀여운 카드 포스터 적합 이미지를 생성합니다!'
+                </p>
               </div>
             )}
           </p>

--- a/card-capture/src/hooks/useIsMobile.tsx
+++ b/card-capture/src/hooks/useIsMobile.tsx
@@ -21,7 +21,7 @@ const useIsMobile = (width?: number) => {
   // 너비가 640px일 때 요소를
   const isMobile = windowWidth <= (width ? width : 640);
 
-  return { isMobile };
+  return { isMobile, windowWidth };
 };
 
 export default useIsMobile;

--- a/card-capture/src/hooks/useParseTemplateData.tsx
+++ b/card-capture/src/hooks/useParseTemplateData.tsx
@@ -1,0 +1,16 @@
+import { useEffect, useState } from 'react';
+import { Card } from '@/store/useCardsStore/type';
+import { jsonUtils } from '@/utils';
+
+const useParseTemplateData = (editor: string) => {
+  const [templateData, setTemplateData] = useState<Card[]>([]);
+
+  useEffect(() => {
+    const parsedData = jsonUtils.parseEscapedJson(editor);
+    setTemplateData(parsedData);
+  }, [editor]);
+
+  return templateData;
+};
+
+export default useParseTemplateData;

--- a/card-capture/src/types/template.types.ts
+++ b/card-capture/src/types/template.types.ts
@@ -10,7 +10,7 @@ export type Phrase = {
 };
 
 export type Prompt = {
-  phraseDto: Phrase;
+  phraseDetails: Phrase;
   purpose: string;
   color: string;
   model: string;


### PR DESCRIPTION
## 📝 설명
- 템플릿 조회 페이지 퍼블리싱 후에 API 연결 + 반응형 적용
- Poster 컴포넌트(에디터 dom에 렌더링하는 컴포넌트) 사용하여 mypage 미리보기 구현

## 💡 관련 이슈
- #63 

## 📌 작업 내용

### 📍 템플릿 조회 페이지 퍼블리싱
```
📦 
├─ app
│  └─ templates
│     └─ [templateId]
│        ├─ page.tsx
│        └─ templateContent.tsx
└─ components
   └─ templates
      ├─ TemplateImage
      └─ TemplatePrompt
```
#### `TemplateImage`
- 유효한 이미지 URL인지 확인하는 기능 구현
   - 클라이언트 사이드에서 `img.onload =() =>`를 사용하여 직접 로드해보고 성공한 경우에만 이미지로 로딩
   - 로드 실패한 경우 `Poster` 컴포넌트 사용하여 dom으로 직접 렌더링 진행
   - 현재는 임시 이미지가 들어가 있는 상태라 구현은 되어있지만 dom으로 렌더링 진행 (임시 이미지와 실제 포스터 불일치함)
``` 
 useEffect(() => {
    if (!fileUrl) return;

    const img = new window.Image();
    img.onload = () => setIsValidImage(true);
    img.onerror = () => setIsValidImage(false);
    img.src = fileUrl;
  }, [fileUrl]);
```
- 화면 사이즈에 따라 `Poster`에게 다른 사이즈 전달하기
   - if문을 사용하여 일일히 넣어줬는데 hook으로 분리하거나 더 깔끔하게 사용할 방법 있을지 고민

#### `TemplatePrompt`
- Prompt 페이지에서 사용한 스타일링 사용하여 간단하게 퍼블리싱 완료

### 📍 mypage 템플릿 미리보기 구현
#### `Poster` 사용하여 미리보기 구현
- 생각보다 로딩이 빨라서 사용해도 괜찮을 것이라고 판단함. 그러나 추후에는 img로 더 빠르게 로딩될 수 있게 개선할 계획
- `Poster` 컴포넌트가 기본적으로 가진 border 때문에 다른 div로 감쌌을 때 완벽하게 cover되지 않는 문제 발생
  - `hasBorder` props를 추가하여 border 존재 여부를 선택할 수 있도록 변경함 

### 📍 string으로 된 카드 데이터를 Card 형식으로 변경해주는 `useParseTemplateData` hook 구현
- 여러번 사용되는 것 같아서 hook으로 분리해서 사용함

## 📷 스크린샷
<img width="1028" alt="스크린샷 2024-09-19 오후 8 07 56" src="https://github.com/user-attachments/assets/accc62e2-d98d-45f8-b1f8-79c2d6891690">
<img width="967" alt="스크린샷 2024-09-19 오후 8 08 26" src="https://github.com/user-attachments/assets/16195c94-3293-49b5-85be-ec72e1769544">
<img width="339" alt="스크린샷 2024-09-19 오후 8 08 56" src="https://github.com/user-attachments/assets/91d6ad53-594b-49af-a0a2-234e37c33384">
<img width="343" alt="스크린샷 2024-09-19 오후 8 09 08" src="https://github.com/user-attachments/assets/6567ddcc-cac6-4d97-a2db-d6a8197448bf">



## 기타 사항
- 서버에서 가져온 데이터를 props로 데이터를 전달하는 경우에, 데이터가 받아와지지 않았을 경우 undefined가 되면서 타입 에러가 발생하는데 해당 오류는 어디서 어떻게 처리하는게 좋을까? 
   - 현재는 early return 써서 빈 컴포넌트 반환하게 해뒀는데 어떻게 처리하는게 타입스크립트 답게 처리하는 걸지 고민중
- 반응형 진짜 재미없다..
- 그래도 하루만에 feature 쳐내기 성공