### PR TITLE
[Feature] 에디터 command 기능 구현

### DIFF
--- a/card-capture/src/components/editor/EditingArea/components/FocusBox/FocusBox.tsx
+++ b/card-capture/src/components/editor/EditingArea/components/FocusBox/FocusBox.tsx
@@ -141,26 +141,31 @@ const FocusBox = ({ children, cardId, layerId, type, initialMouseDown }: Props) 
           transformOrigin: 'center',
           pointerEvents: 'none', // 이벤트가 통과되어서 아래있는 요소(자식요소 아니고 아래 위치 요소)가 이벤트를 받도록 함
         }}
+        onClick={stopPropagation}
       >
         {/* 11시,1시,5시,7시 크기조절 바 */}
         <div
           className="absolute -left-1.5 -top-1.5 h-3 w-3 cursor-nwse-resize rounded-full border-2 border-main bg-white"
           onPointerDown={e => resizePointerDownHandler(e, 'nw')}
+          onClick={stopPropagation}
           style={{ pointerEvents: 'auto' }} // control 버튼들은 이벤트 받을 수 있도록 설정
         ></div>
         <div
           className="absolute -right-1.5 -top-1.5 h-3 w-3 cursor-nesw-resize rounded-full border-2 border-main bg-white"
           onPointerDown={e => resizePointerDownHandler(e, 'ne')}
+          onClick={stopPropagation}
           style={{ pointerEvents: 'auto' }}
         ></div>
         <div
           className="absolute -bottom-1.5 -left-1.5 h-3 w-3 cursor-nesw-resize rounded-full border-2 border-main bg-white"
           onPointerDown={e => resizePointerDownHandler(e, 'sw')}
+          onClick={stopPropagation}
           style={{ pointerEvents: 'auto' }}
         ></div>
         <div
           className="absolute -bottom-1.5 -right-1.5 h-3 w-3 cursor-nwse-resize rounded-full border-2 border-main bg-white"
           onPointerDown={e => resizePointerDownHandler(e, 'se')}
+          onClick={stopPropagation}
           style={{ pointerEvents: 'auto' }}
         ></div>
 
@@ -168,21 +173,25 @@ const FocusBox = ({ children, cardId, layerId, type, initialMouseDown }: Props) 
         <div
           className="absolute -top-1.5 left-2/4 h-2.5 w-7 -translate-x-1/2 cursor-row-resize rounded border-[1.5px] border-main bg-white"
           onPointerDown={e => resizePointerDownHandler(e, 'n')}
+          onClick={stopPropagation}
           style={{ pointerEvents: 'auto' }}
         ></div>
         <div
           className="absolute -right-1.5 top-1/2 h-7 w-2.5 -translate-y-1/2 cursor-col-resize rounded border-[1.5px] border-main bg-white"
           onPointerDown={e => resizePointerDownHandler(e, 'e')}
+          onClick={stopPropagation}
           style={{ pointerEvents: 'auto' }}
         ></div>
         <div
           className="absolute -bottom-1.5 left-2/4 h-2.5 w-7 -translate-x-1/2 cursor-row-resize rounded border-[1.5px] border-main bg-white"
           onPointerDown={e => resizePointerDownHandler(e, 's')}
+          onClick={stopPropagation}
           style={{ pointerEvents: 'auto' }}
         ></div>
         <div
           className="absolute -left-1.5 top-1/2 h-7 w-2.5 -translate-y-1/2 cursor-col-resize rounded border-[1.5px] border-main bg-white"
           onPointerDown={e => resizePointerDownHandler(e, 'w')}
+          onClick={stopPropagation}
           style={{ pointerEvents: 'auto' }}
         ></div>
 
@@ -224,6 +233,7 @@ const FocusBox = ({ children, cardId, layerId, type, initialMouseDown }: Props) 
                 isDrag ? 'cursor-grabbing' : 'cursor-grab'
               }`}
               style={{ opacity: curPosition.opacity / 100 }}
+              onClick={stopPropagation}
             >
               {layer.type === 'text' && React.isValidElement(children)
                 ? React.cloneElement(children, { isDoubleClicked })

--- a/card-capture/src/components/editor/EditingArea/components/FocusBox/components/InlineLayerEditBox/InlineLayerEditBox.tsx
+++ b/card-capture/src/components/editor/EditingArea/components/FocusBox/components/InlineLayerEditBox/InlineLayerEditBox.tsx
@@ -3,18 +3,33 @@ import PasteIcon from '@/components/common/Icon/PasteIcon';
 import TrashIcon from '@/components/common/Icon/TrashIcon';
 import useDeleteLayer from '@/components/editor/EditingArea/components/FocusBox/hooks/useDeleteLayer';
 import { useFocusStore } from '@/store/useFocusStore';
+import { useCommandStore } from '@/store/useCommandStore';
 
 const InlineLayerEditBox = () => {
   const focusedCardId = useFocusStore(state => state.focusedCardId);
+  const focusedLayerId = useFocusStore(state => state.focusedLayerId);
+
+  // 삭제 기능
   const { deleteLayerOnClickHandler } = useDeleteLayer({ cardId: focusedCardId });
+
+  // 복사, 붙여넣기 기능
+  const { copy, paste } = useCommandStore();
+
+  const copyHandler = () => {
+    copy(focusedCardId, focusedLayerId);
+  };
+
+  const pasteHandler = () => {
+    paste(focusedCardId);
+  };
 
   return (
     <div className="flex h-[47px] w-[120px] flex-row items-center justify-between rounded-[8px] bg-white px-4 shadow-base">
-      <button disabled={true}>
-        <CopyIcon width={17} strokeWidth={1.5} className="text-gray3" />
+      <button onClick={copyHandler}>
+        <CopyIcon width={17} strokeWidth={1.5} />
       </button>
-      <button disabled={true}>
-        <PasteIcon width={27} className="text-gray3" />
+      <button onClick={pasteHandler}>
+        <PasteIcon width={27} />
       </button>
       <button onClick={deleteLayerOnClickHandler}>
         <TrashIcon width={17} strokeWidth={1.5} />

--- a/card-capture/src/components/editor/EditingArea/components/FocusBox/hooks/useDrag.tsx
+++ b/card-capture/src/components/editor/EditingArea/components/FocusBox/hooks/useDrag.tsx
@@ -105,8 +105,8 @@ const useDrag = ({
     const dx = e.clientX - initialPositionRef.current.x;
     const dy = e.clientY - initialPositionRef.current.y;
 
-    // 임계값 이하로 움직였으면 이동에 반영하지 않음
-    if (Math.abs(dx) > DRAG_THRESHOLD && Math.abs(dy) > DRAG_THRESHOLD) {
+    // 둘 다 임계값 이하로 움직였으면 이동에 반영하지 않음
+    if (Math.abs(dx) > DRAG_THRESHOLD || Math.abs(dy) > DRAG_THRESHOLD) {
       setPosition(cardId, layerId, { ...curPosition, ...calculateCurPosition(e) });
     }
   };

--- a/card-capture/src/components/editor/EditingArea/components/FocusBox/hooks/useDrag.tsx
+++ b/card-capture/src/components/editor/EditingArea/components/FocusBox/hooks/useDrag.tsx
@@ -57,7 +57,7 @@ const useDrag = ({
 
   /**
    * Layer pointerDown시 실행되는 로직
-   * 이벤트 등록을 위해 상태 true로 변경.
+   * 이벤트 등록을 위해 상태 true로 변경. 초기값 기억해서 임계값 이하 이동은 무시
    */
   const pointerDownDragHandler = (e: React.PointerEvent | React.MouseEvent) => {
     e.stopPropagation();
@@ -93,6 +93,7 @@ const useDrag = ({
   /**
    * 드래그가 끝났을 때 실행되는 로직
    * 마지막 위치를 전역 상태에 저장하고, 기록된 상태를 초기화
+   * 임계값 처리를 해주지 않으면 layer -> focus 컴포넌트 변경시에 발생하는 미세한 이동이 적용되어서 불편함 존재
    */
   const pointerUpDragHandler = (e: PointerEvent | MouseEvent) => {
     if (!initialPositionRef.current) return;
@@ -104,6 +105,7 @@ const useDrag = ({
     const dx = e.clientX - initialPositionRef.current.x;
     const dy = e.clientY - initialPositionRef.current.y;
 
+    // 임계값 이하로 움직였으면 이동에 반영하지 않음
     if (Math.abs(dx) > DRAG_THRESHOLD && Math.abs(dy) > DRAG_THRESHOLD) {
       setPosition(cardId, layerId, { ...curPosition, ...calculateCurPosition(e) });
     }

--- a/card-capture/src/components/editor/EditingArea/views/CardArea.tsx
+++ b/card-capture/src/components/editor/EditingArea/views/CardArea.tsx
@@ -17,6 +17,7 @@ import useAmplitudeContext from '@/hooks/useAmplitudeContext';
 import usePosterDownloader from '@/hooks/usePosterDownloader';
 import DownloadProgressModal from '@/components/common/Progress/DownloadProgressModal';
 import ExportButton from '@/components/editor/EditingArea/views/ExportButton';
+import { useCommandStore } from '@/store/useCommandStore';
 
 const CardArea = ({ card }: { card: Card }) => {
   const cardId = card.id;
@@ -73,6 +74,38 @@ const CardArea = ({ card }: { card: Card }) => {
    * 에디터 페이지에서 버튼 클릭에 대한 tracking
    */
   const { trackAmplitudeEvent } = useAmplitudeContext();
+
+  /**
+   *
+   */
+  const { redo, undo } = useCommandStore();
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.ctrlKey || event.metaKey) {
+        // metaKey는 Mac의 command 키
+        switch (event.key.toLowerCase()) {
+          case 'z':
+            if (cardId !== null && focusedLayerId !== null) {
+              event.preventDefault();
+
+              if (event.shiftKey) {
+                redo();
+              } else {
+                undo();
+              }
+              break;
+            }
+        }
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, []);
 
   return (
     <div className="flex flex-1 flex-col items-center justify-center gap-[10px] bg-editorbg">

--- a/card-capture/src/components/editor/EditingArea/views/CardArea.tsx
+++ b/card-capture/src/components/editor/EditingArea/views/CardArea.tsx
@@ -78,7 +78,7 @@ const CardArea = ({ card }: { card: Card }) => {
   /**
    *
    */
-  const { redo, undo } = useCommandStore();
+  const { redo, undo, copy, paste } = useCommandStore();
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
@@ -94,8 +94,16 @@ const CardArea = ({ card }: { card: Card }) => {
               } else {
                 undo();
               }
-              break;
             }
+            break;
+
+          case 'c':
+            copy(cardId, focusedLayerId);
+            break;
+
+          case 'v':
+            paste(cardId);
+            break;
         }
       }
     };
@@ -105,7 +113,7 @@ const CardArea = ({ card }: { card: Card }) => {
     return () => {
       document.removeEventListener('keydown', handleKeyDown);
     };
-  }, []);
+  }, [cardId, focusedLayerId]);
 
   return (
     <div className="flex flex-1 flex-col items-center justify-center gap-[10px] bg-editorbg">

--- a/card-capture/src/components/editor/EditingArea/views/CardArea.tsx
+++ b/card-capture/src/components/editor/EditingArea/views/CardArea.tsx
@@ -76,7 +76,7 @@ const CardArea = ({ card }: { card: Card }) => {
   const { trackAmplitudeEvent } = useAmplitudeContext();
 
   /**
-   *
+   * command로 요소 조작하는 hook 사용
    */
   const { redo, undo, copy, paste } = useCommandStore();
 

--- a/card-capture/src/components/editor/EditingArea/views/LayerAddBox.tsx
+++ b/card-capture/src/components/editor/EditingArea/views/LayerAddBox.tsx
@@ -5,6 +5,7 @@ import { useCardsStore } from '@/store/useCardsStore';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { ShapeType } from '@/store/useCardsStore/type';
 import { useFocusStore } from '@/store/useFocusStore';
+import React from 'react';
 
 const LayerAddBox = ({ cardId }: { cardId: number }) => {
   /**
@@ -12,7 +13,8 @@ const LayerAddBox = ({ cardId }: { cardId: number }) => {
    */
   const addTextLayer = useCardsStore(state => state.addTextLayer);
 
-  const addTextLayerHandler = () => {
+  const addTextLayerHandler = (e: React.PointerEvent | React.MouseEvent) => {
+    e.stopPropagation();
     addTextLayer(cardId);
   };
 
@@ -22,7 +24,9 @@ const LayerAddBox = ({ cardId }: { cardId: number }) => {
   const focusedCardId = useFocusStore(state => state.focusedCardId);
   const addShapeLayer = useCardsStore(state => state.addShapeLayer);
 
-  const addShapeLayerHandler = (type: ShapeType) => {
+  const addShapeLayerHandler = (e: React.PointerEvent | React.MouseEvent, type: ShapeType) => {
+    e.stopPropagation();
+
     addShapeLayer(focusedCardId, type);
   };
 
@@ -41,13 +45,13 @@ const LayerAddBox = ({ cardId }: { cardId: number }) => {
         <PopoverContent className="mt-2 flex flex-row p-1.5" style={{ zIndex: 10000 }}>
           <div className="flex flex-row gap-[5px]">
             <button
-              onClick={() => addShapeLayerHandler('circle')}
+              onClick={e => addShapeLayerHandler(e, 'circle')}
               className="flex h-[30px] w-[30px] cursor-pointer items-center justify-center overflow-hidden rounded-[5px] hover:bg-itembg"
             >
               <div className="h-[20px] w-[20px] rounded-full bg-gray7" />
             </button>
             <button
-              onClick={() => addShapeLayerHandler('triangle')}
+              onClick={e => addShapeLayerHandler(e, 'triangle')}
               className="flex h-[30px] w-[30px] cursor-pointer items-center justify-center overflow-hidden rounded-[5px] hover:bg-itembg"
             >
               <div
@@ -59,13 +63,13 @@ const LayerAddBox = ({ cardId }: { cardId: number }) => {
               />
             </button>
             <button
-              onClick={() => addShapeLayerHandler('rect')}
+              onClick={e => addShapeLayerHandler(e, 'rect')}
               className="flex h-[30px] w-[30px] cursor-pointer items-center justify-center overflow-hidden rounded-[5px] hover:bg-itembg"
             >
               <div className="h-[18px] w-[18px] bg-gray7" />
             </button>
             <button
-              onClick={() => addShapeLayerHandler('star')}
+              onClick={e => addShapeLayerHandler(e, 'star')}
               className="flex h-[30px] w-[30px] cursor-pointer items-center justify-center overflow-hidden rounded-[5px] hover:bg-itembg"
             >
               <div

--- a/card-capture/src/components/editor/Tab/components/EditTab/IllustrationEditBox/components/ShapeModalBox.tsx
+++ b/card-capture/src/components/editor/Tab/components/EditTab/IllustrationEditBox/components/ShapeModalBox.tsx
@@ -17,7 +17,7 @@ const ShapeModalBox = () => {
   /**
    * 색상 변경되면 store에 변경된 Layer 색상 업데이트하는 로직
    */
-  const [color, setColor] = useColor(focusedShape?.color || '#AAAAAA');
+  const [color, setColor] = useColor(focusedShape?.color || '#DDDDDD');
   const setShapeLayerColor = useCardsStore(state => state.setShapeLayerColor);
 
   useEffect(() => {

--- a/card-capture/src/components/editor/Tab/components/EditTab/common/SizeBox.tsx
+++ b/card-capture/src/components/editor/Tab/components/EditTab/common/SizeBox.tsx
@@ -40,11 +40,11 @@ const SizeBox = ({ type }: SizeBoxProps) => {
    */
   useEffect(() => {
     if (!position) return;
-    if (focusedLayerType !== type) return;
-
-    setWidth(Math.floor(position.width));
-    setHeight(Math.floor(position.height));
-    setRotate(Math.floor(position.rotate));
+    if (focusedLayerType === type || (focusedLayerType === 'illust' && type === 'shape')) {
+      setWidth(Math.floor(position.width));
+      setHeight(Math.floor(position.height));
+      setRotate(Math.floor(position.rotate));
+    }
   }, [position]);
 
   /**

--- a/card-capture/src/store/useCardsStore/index.ts
+++ b/card-capture/src/store/useCardsStore/index.ts
@@ -333,9 +333,9 @@ export const useCardsStore = create(
               if (!card) return null;
 
               const layer = card.layers.find((layer: Layer) => layer.id === layerId);
-              if (layer && layer.type === 'shape') {
-                (layer.content as Shape).color = color;
-              }
+              if (!layer || layer.type !== 'shape' || (layer.content as Shape).color === color) return;
+
+              (layer.content as Shape).color = color;
 
               const beforeLayer = get().getLayer(cardId, layerId);
               if (!beforeLayer) return;

--- a/card-capture/src/store/useCardsStore/index.ts
+++ b/card-capture/src/store/useCardsStore/index.ts
@@ -336,7 +336,7 @@ export const useCardsStore = create(
               }
 
               const beforeLayer = get().getLayer(cardId, layerId);
-              if (!beforeLayer) return null;
+              if (!beforeLayer) return;
 
               useCommandStore.getState().addCommand({
                 type: 'MODIFY_LAYER',

--- a/card-capture/src/store/useCommandStore/index.ts
+++ b/card-capture/src/store/useCommandStore/index.ts
@@ -122,7 +122,7 @@ const getCurrentCommand = (command: Command): Command => {
     case 'DELETE_LAYER':
     case 'MODIFY_LAYER':
       const layer = cardsStore.getLayer(command.cardId, command.layerId);
-      if (!layer) return command;
+      if (!layer) return { ...command };
 
       return {
         ...command,
@@ -137,7 +137,7 @@ const getCurrentCommand = (command: Command): Command => {
         backgroundData: bg,
       };
     default:
-      return command;
+      return { ...command };
   }
 };
 

--- a/card-capture/src/store/useCommandStore/index.ts
+++ b/card-capture/src/store/useCommandStore/index.ts
@@ -36,7 +36,7 @@ export const useCommandStore = create<commandStore>()((set, get) => ({
           draft.future.push(currentCommand);
 
           // 과거 기록 재실행
-          executeCommand(JSON.parse(JSON.stringify(pastCommand)));
+          undoCommand(JSON.parse(JSON.stringify(pastCommand)));
         }
       }),
     ),
@@ -93,6 +93,41 @@ const executeCommand = (command: Command) => {
   const cardStore = useCardsStore.getState();
 
   switch (type) {
+    case 'ADD_LAYER':
+      if ('layerData' in command && command.layerData) {
+        cardStore.addLayer(cardId, command.layerData as Layer);
+      }
+      break;
+    case 'DELETE_LAYER':
+      if ('layerId' in command && command.layerId !== undefined) {
+        cardStore.deleteLayer(cardId, command.layerId);
+      }
+      break;
+    case 'MODIFY_LAYER':
+      if ('layerId' in command && 'layerData' in command && command.layerId !== undefined && command.layerData) {
+        cardStore.setLayer(cardId, command.layerId, command.layerData);
+      }
+  }
+};
+
+/**
+ * 명령을 반대로 실행하는 함수
+ */
+const undoCommand = (command: Command) => {
+  const { type, cardId } = command;
+  const cardStore = useCardsStore.getState();
+
+  switch (type) {
+    case 'ADD_LAYER':
+      if ('layerData' in command && command.layerId) {
+        cardStore.deleteLayer(cardId, command.layerId);
+      }
+      break;
+    case 'DELETE_LAYER':
+      if ('layerId' in command && command.layerData && command.layerId !== undefined) {
+        cardStore.addLayer(cardId, command.layerData);
+      }
+      break;
     case 'MODIFY_LAYER':
       if ('layerId' in command && 'layerData' in command && command.layerId !== undefined && command.layerData) {
         cardStore.setLayer(cardId, command.layerId, command.layerData);

--- a/card-capture/src/store/useCommandStore/index.ts
+++ b/card-capture/src/store/useCommandStore/index.ts
@@ -13,6 +13,9 @@ type commandStore = {
   addCommand: (command: Command) => void;
   undo: () => void;
   redo: () => void;
+
+  copy: (cardId: number, layerId: number) => void;
+  paste: (cardId: number) => void;
 };
 
 export const useCommandStore = create<commandStore>()((set, get) => ({
@@ -61,6 +64,28 @@ export const useCommandStore = create<commandStore>()((set, get) => ({
         }
       }),
     ),
+
+  copy: (cardId, layerId) =>
+    set(
+      produce(draft => {
+        const cardsStore = useCardsStore.getState();
+        const currentLayer = cardsStore.getLayer(cardId, layerId);
+
+        if (!currentLayer) return;
+
+        draft.clipboard = currentLayer;
+      }),
+    ),
+  paste: cardId => {
+    set(
+      produce(draft => {
+        if (!draft.clipboard) return;
+
+        const cardsStore = useCardsStore.getState();
+        cardsStore.addDuplicateLayer(cardId, JSON.parse(JSON.stringify(draft.clipboard)));
+      }),
+    );
+  },
 }));
 
 /**

--- a/card-capture/src/store/useCommandStore/index.ts
+++ b/card-capture/src/store/useCommandStore/index.ts
@@ -1,0 +1,101 @@
+import { create } from 'zustand';
+import { Command } from '@/store/useCommandStore/type';
+import { produce } from 'immer';
+import { Layer } from '@/store/useCardsStore/type';
+import { useCardsStore } from '@/store/useCardsStore';
+
+type commandStore = {
+  past: Command[];
+  future: Command[];
+  clipboard: Layer | null;
+
+  addCommand: (command: Command) => void;
+  undo: () => void;
+  redo: () => void;
+};
+
+export const useCommandStore = create<commandStore>()((set, get) => ({
+  past: [],
+  future: [],
+  clipboard: null,
+
+  addCommand: command =>
+    set(
+      produce(draft => {
+        // 새로 수행된 작업을 기록하고, 미래는 초기화
+        draft.past.push(command);
+        draft.future = [];
+      }),
+    ),
+  undo: () =>
+    set(
+      produce(draft => {
+        if (draft.past.length > 0) {
+          const pastCommand = draft.past.pop();
+          const currentCommand = getCurrentCommand(pastCommand);
+          draft.future.push(currentCommand);
+
+          // 과거 기록 재실행
+          executeCommand(JSON.parse(JSON.stringify(pastCommand)));
+        }
+      }),
+    ),
+  redo: () =>
+    set(
+      produce(draft => {
+        if (draft.future.length > 0) {
+          const futureCommand = draft.future.pop();
+          const currentCommand = getCurrentCommand(futureCommand);
+          draft.past.push(currentCommand);
+
+          executeCommand(JSON.parse(JSON.stringify(futureCommand)));
+        }
+      }),
+    ),
+}));
+
+/**
+ * 현재 상태에 대한 command 가져오는 함수
+ */
+const getCurrentCommand = (command: Command): Command => {
+  const cardsStore = useCardsStore.getState();
+
+  switch (command.type) {
+    case 'ADD_LAYER':
+    case 'DELETE_LAYER':
+    case 'MODIFY_LAYER':
+      const layer = cardsStore.getLayer(command.cardId, command.layerId);
+      if (!layer) return command;
+
+      return {
+        ...command,
+        layerData: layer,
+      };
+    case 'MODIFY_BACKGROUND':
+      const bg = cardsStore.getBackground(command.cardId);
+      if (!bg) return command;
+
+      return {
+        ...command,
+        backgroundData: bg,
+      };
+    default:
+      return command;
+  }
+};
+
+/**
+ * 명령대로 실행하는 힘수
+ * 명령에 맞게 값을 변경,삭제,추가함 -> useCardStore의 값을 변경함
+ */
+const executeCommand = (command: Command) => {
+  const { type, cardId } = command;
+  const cardStore = useCardsStore.getState();
+
+  switch (type) {
+    case 'MODIFY_LAYER':
+      if ('layerId' in command && 'layerData' in command && command.layerId !== undefined && command.layerData) {
+        cardStore.setLayer(cardId, command.layerId, command.layerData);
+      }
+  }
+};

--- a/card-capture/src/store/useCommandStore/index.ts
+++ b/card-capture/src/store/useCommandStore/index.ts
@@ -34,7 +34,7 @@ export const useCommandStore = create<commandStore>()((set, get) => ({
 
           if (areCommandsEqual(pastCommand, command)) return;
         }
-
+        
         // 새로 수행된 작업을 기록하고, 미래는 초기화
         draft.past.push(command);
         draft.future = [];
@@ -47,7 +47,7 @@ export const useCommandStore = create<commandStore>()((set, get) => ({
           const pastCommand = draft.past.pop();
           const currentCommand = getCurrentCommand(pastCommand);
           draft.future.push(currentCommand);
-          // 과거 기록 재실행
+
           undoCommand(JSON.parse(JSON.stringify(pastCommand)));
         }
       }),
@@ -159,7 +159,7 @@ const undoCommand = (command: Command) => {
 
   switch (type) {
     case 'ADD_LAYER':
-      if ('layerData' in command && command.layerId) {
+      if ('layerData' in command && command.layerId !== undefined) {
         cardStore.deleteLayer(cardId, command.layerId);
       }
       break;

--- a/card-capture/src/store/useCommandStore/index.ts
+++ b/card-capture/src/store/useCommandStore/index.ts
@@ -116,6 +116,11 @@ const executeCommand = (command: Command) => {
       if ('layerId' in command && 'layerData' in command && command.layerId !== undefined && command.layerData) {
         cardStore.setLayer(cardId, command.layerId, command.layerData);
       }
+      break;
+    case 'MODIFY_BACKGROUND':
+      if ('backgroundData' in command) {
+        cardStore.setBackground(cardId, command.backgroundData);
+      }
   }
 };
 
@@ -141,6 +146,11 @@ const undoCommand = (command: Command) => {
     case 'MODIFY_LAYER':
       if ('layerId' in command && 'layerData' in command && command.layerId !== undefined && command.layerData) {
         cardStore.setLayer(cardId, command.layerId, command.layerData);
+      }
+      break;
+    case 'MODIFY_BACKGROUND':
+      if ('backgroundData' in command) {
+        cardStore.setBackground(cardId, command.backgroundData);
       }
   }
 };

--- a/card-capture/src/store/useCommandStore/type.ts
+++ b/card-capture/src/store/useCommandStore/type.ts
@@ -32,3 +32,12 @@ type CardCommand = BaseCommand & {
 };
 
 export type Command = LayerCommand | BackgroundCommand | CardCommand;
+
+// 타입 가드 함수
+export const isLayerCommand = (command: Command): command is LayerCommand => {
+  return ['ADD_LAYER', 'DELETE_LAYER', 'MODIFY_LAYER'].includes(command.type);
+};
+
+export const isBackgroundCommand = (command: Command): command is BackgroundCommand => {
+  return command.type === 'MODIFY_BACKGROUND';
+};

--- a/card-capture/src/store/useCommandStore/type.ts
+++ b/card-capture/src/store/useCommandStore/type.ts
@@ -1,0 +1,34 @@
+import { Background, Card, Layer } from '@/store/useCardsStore/type';
+
+export type CommandType =
+  | 'ADD_LAYER'
+  | 'DELETE_LAYER'
+  | 'MODIFY_LAYER'
+  | 'MODIFY_BACKGROUND'
+  | 'ADD_CARD'
+  | 'DELETE_CARD'
+  | 'COPY'
+  | 'PASTE';
+
+type BaseCommand = {
+  type: CommandType;
+  cardId: number;
+};
+
+type LayerCommand = BaseCommand & {
+  type: 'ADD_LAYER' | 'DELETE_LAYER' | 'MODIFY_LAYER' | 'COPY' | 'PASTE';
+  layerId: number;
+  layerData: Layer;
+};
+
+type BackgroundCommand = BaseCommand & {
+  type: 'MODIFY_BACKGROUND';
+  backgroundData: Partial<Background>;
+};
+
+type CardCommand = BaseCommand & {
+  type: 'ADD_CARD' | 'DELETE_CARD';
+  cardData: Card;
+};
+
+export type Command = LayerCommand | BackgroundCommand | CardCommand;

--- a/card-capture/src/utils/commonUtils.ts
+++ b/card-capture/src/utils/commonUtils.ts
@@ -1,6 +1,6 @@
 /**
  * 객체를 깊은 비교하는 함수
- * 내부의 key-value들이 같은지 제귀적으로 확인함
+ * 내부의 key-value들이 같은지 재귀적으로 확인함
  */
 const isEqual = (obj1: any, obj2: any): boolean => {
   // 완전히 같은 객체, 같은 값을 가진 원사타입이면 true

--- a/card-capture/src/utils/commonUtils.ts
+++ b/card-capture/src/utils/commonUtils.ts
@@ -20,7 +20,7 @@ const isEqual = (obj1: any, obj2: any): boolean => {
     if (!keys2.includes(key) || !isEqual(obj1[key], obj2[key])) return false;
   }
 
-  return false;
+  return true;
 };
 
 export default { isEqual };

--- a/card-capture/src/utils/commonUtils.ts
+++ b/card-capture/src/utils/commonUtils.ts
@@ -1,0 +1,26 @@
+/**
+ * 객체를 깊은 비교하는 함수
+ * 내부의 key-value들이 같은지 제귀적으로 확인함
+ */
+const isEqual = (obj1: any, obj2: any): boolean => {
+  // 완전히 같은 객체, 같은 값을 가진 원사타입이면 true
+  if (obj1 === obj2) return true;
+
+  // 객체가 아니거나 null이면 false
+  if (typeof obj1 !== 'object' || obj1 === null || typeof obj2 !== 'object' || obj2 === null) return false;
+
+  const keys1 = Object.keys(obj1);
+  const keys2 = Object.keys(obj2);
+
+  // key의 개수가 같지 않으면 false;
+  if (keys1.length !== keys2.length) return false;
+
+  for (const key of keys1) {
+    // 각 key의 value들이 같은지 재귀로 검사
+    if (!keys2.includes(key) || !isEqual(obj1[key], obj2[key])) return false;
+  }
+
+  return false;
+};
+
+export default { isEqual };

--- a/card-capture/src/utils/index.ts
+++ b/card-capture/src/utils/index.ts
@@ -3,5 +3,6 @@ import jsonUtils from './jsonUtils';
 import tokenUtils from './tokenUtils';
 import userUtils from './userUtils';
 import editorUtils from './editorUtils';
+import commonUtils from './commonUtils';
 
-export { authUtils, jsonUtils, tokenUtils, userUtils, editorUtils };
+export { authUtils, jsonUtils, tokenUtils, userUtils, editorUtils, commonUtils };


### PR DESCRIPTION
## 📝 설명
- 에디터에서 요소의 변경을 추적하고 되돌릴 수 있는 command 기능들을 구현함

## 💡 관련 이슈
- #74 

## 📌 작업 내용

### 📍 useCommandStore 구현
- command들을 기록할 Zustand store 구현
   - 커맨드 타입 정의
   - 커맨드 타입 가드 구현
   - 커맨드를 저장할 필드 선언 (past, future, clipboard)


### 📍 커맨드 동작 구현
#### addCommand
- 커맨드를 past 스택에 기록하는 기능
- 직전의 커맨드와 같은 커맨드라면 추가하지 않는다 -> 이를 확인하기 위해 areCommandsEqual 구현
   - areCommandsEqual : 두개의 커맨드의 타입, 아이디, 레이어 데이터가 같은지 확인하는 함수
   - 객체를 깊은 비교하는 isEqaul 함수 구현하여 레이어 데이터를 검사함
 
---
#### isEqual
   - 재귀 사용해서 key-value값 검사
```typescript
/**
 * 두 커맨드가 완전히 같은지 확인하는 함수 (깊은 비교)
 * 커맨드가 같은 경우에는 스택에 추가하지 않기 위해서 사용됨
 */
const areCommandsEqual = (command1: Command, command2: Command): boolean => {
  // 타입, 카드 아이디 비교
  if (command1.type !== command2.type || command1.cardId !== command2.cardId) {
    return false;
  }

  // LayerCommand 비교
  if (isLayerCommand(command1) && isLayerCommand(command2)) {
    return command1.layerId === command2.layerId && commonUtils.isEqual(command1.layerData, command2.layerData);
  }

  // BackgroundCommand 비교
  if (isBackgroundCommand(command1) && isBackgroundCommand(command2)) {
    return commonUtils.isEqual(command1.backgroundData, command2.backgroundData);
  }

  return false;
};
```
---

#### undo(ctrl + z)
  - past에 저장된 커맨드를 꺼내서 반대로 적용하는(다시 되돌리는) 기능 ('추가'였으면 -> '삭제' / '수정' -> '수정)
  - 그리고 사라지게 되는 현재 상태를 커맨드로 만들어서 future에 저장
 
#### redo(ctrl + shift + z)
- future에 저장된 커맨드를 꺼내서 다시 적용하는 기능 (되돌리는 기능이 아니므로 그냥 다시 적용하면 된다)
- 그리고 현재의 상태는 과거가 되므로 커맨드로 만들어서 past에 저장

#### copy (ctrl + c)
- 현재 레이어를 추출하여 clipboard에 저장

#### paste (ctrl + v)
- clipboard에 있는 레이어를 카드에 추가
- 추가하는 행동도 history에 남아야 하므로 past에 커맨드 추가

---
#### 기타 함수들
- getCurrentCommand : 현재 상태를 커맨드로 만들어주는 함수
- excuteCommand : 커맨드를 실행하여 useCardStore에 반영하는 함수
- undoCommand : 커맨드를 반대로 실행하여 useCardStore에 반영하는 함수 

### 📍 useCardStore에서 변경 발생시 커맨드 등록
- 요소 변경을 발생시키는 함수에 커맨드 추가 함수 호출
```typescript
useCommandStore.getState().addCommand({
                  type: 'MODIFY_LAYER',
                  cardId,
                  layerId,
                  layerData: beforeLayer,
                });
```

#### ⚠️ paste시에 커맨드가 등록되지 않는 오류 발생
 - paste시에 past에 ADD_LAYER 커맨드가 등록되지 않는 오류 발생
    - 그 당시 구현 방식 : paste -> useCardStore의 addDuplicateLayer 실행 -> useCardStore에서 addCommand 실행 -> useCommandStore에서 커맨드 추가
 - 문제 : 커맨드가 추가 되는데 다시 사라지는 현상 확인.
 - 원인 : 오류 추적 결과 정확한 발생 원인인지는 확실하지 않으나 두개의 스토어에서 서로가 서로를 업데이트 하면서 동기화 문제가 발생한 것으로 파악됨
 - 해결 : 서로 순환참조(서로가 서로의 커맨드를 실행)하는 부분을 없애고, useCardStore가 아닌 useCommandStore 내에서 직접 커맨드 추가


### 📍 LayerBox -> FocusBox 변경시 요소 이동되는 오류 수정
- 원인 : 컴포넌트가 바뀌면서 리렌더링되고, 그에 따라서 커서의 clientX,Y 위치가 미세하게 변경됨
- 문제 : position이 바뀌면서 커맨드가 등록되어서 클릭이 모두 커맨드로 기록되는 불편함 발생
- 해결 : 리렌더링으로 인한 커서위치 변경을 방지하는 것은 어려워서, 이동 offset에 임계값을 두고 임계값 이하 값은 무시
```typescript
const pointerUpDragHandler = (e: PointerEvent | MouseEvent) => {
    if (!initialPositionRef.current) return;

    setDragOffset({ ...INITIAL_DRAG_OFFSET });
    setIsDrag(false);

    // 위치 어느정도 변경되었는지 확인
    const dx = e.clientX - initialPositionRef.current.x;
    const dy = e.clientY - initialPositionRef.current.y;

    // 둘 다 임계값 이하로 움직였으면 이동에 반영하지 않음
    if (Math.abs(dx) > DRAG_THRESHOLD || Math.abs(dy) > DRAG_THRESHOLD) {
      setPosition(cardId, layerId, { ...curPosition, ...calculateCurPosition(e) });
    }
  };
```


![2024-10-235 02 41-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/4383114b-0417-45ce-afd2-48ff95f1a367)


## 기타 사항
- layerId의 존재 여부를 확인할때 ! 으로 확인했다가 0을 무시하는 오류 발생. 원인을 못찾아서 한참 고생함
- 현재 구현방식에 부족한 점이 많아서 command 디자인 패턴 사용해서 리팩토링 할 예정. 커맨드 디자인 패턴 학습 완.
- 커맨드 실행 로그를 기록하기 위한 logger도 작성하려고 함. console.group()을 처음 알게됨
