### PR TITLE
ci : Github Pages에 SSG 배포

### DIFF
--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -5,16 +5,18 @@
 name: Deploy Next.js site to Pages
 
 on:
-  # Runs on pushes targeting the default branch
   push:
-    branches: ["main"]
+    branches:
+      - test-pages
+  #      - main
+  pull_request:
+    branches:
+      - test-pages
+  #      - main
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
-env: 
-  GITHUB_WORKSPACE: /home/runner/work/card-capture-fe/card-capture
-  
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
   contents: read
@@ -31,10 +33,15 @@ jobs:
   # Build job
   build:
     runs-on: ubuntu-latest
+    env:
+      WORKSPACE_PATH: ./card-capture
+
     defaults:
       run:
         shell: bash
-        working-directory: ./card-capture
+        working-directory: ${{ env.WORKSPACE_PATH }}
+    # change working directory path
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -42,12 +49,12 @@ jobs:
       - name: Detect package manager
         id: detect-package-manager
         run: |
-          if [ -f "${{ github.workspace }}/yarn.lock" ]; then
+          if [ -f "yarn.lock" ]; then
             echo "manager=yarn" >> $GITHUB_OUTPUT
             echo "command=install" >> $GITHUB_OUTPUT
             echo "runner=yarn" >> $GITHUB_OUTPUT
             exit 0
-          elif [ -f "${{ github.workspace }}/package.json" ]; then
+          elif [ -f "package.json" ]; then
             echo "manager=npm" >> $GITHUB_OUTPUT
             echo "command=ci" >> $GITHUB_OUTPUT
             echo "runner=npx --no-install" >> $GITHUB_OUTPUT
@@ -61,8 +68,8 @@ jobs:
         with:
           node-version: "18"
           cache: ${{ steps.detect-package-manager.outputs.manager }}
-          cache-dependency-path: ./card-capture/package-lock.json
-          
+          cache-dependency-path: ${{ env.WORKSPACE_PATH }}/package-lock.json
+
       - name: Setup Pages
         uses: actions/configure-pages@v5
         with:
@@ -71,16 +78,20 @@ jobs:
           #
           # You may remove this line if you want to manage the configuration yourself.
           static_site_generator: next
+
       - name: Check shell
         run: ls -al
+
       - name: Install dependencies
         run: ${{ steps.detect-package-manager.outputs.manager }} ${{ steps.detect-package-manager.outputs.command }}
+
       - name: Build with Next.js
         run: ${{ steps.detect-package-manager.outputs.runner }} next build
+
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: ./out
+          path: ${{ env.WORKSPACE_PATH }}/out
 
   # Deployment job
   deploy:

--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -7,12 +7,12 @@ name: Deploy Next.js site to Pages
 on:
   push:
     branches:
-      - test-pages
-  #      - main
+      #      - test-pages
+      - main
   pull_request:
     branches:
-      - test-pages
-  #      - main
+      #      - test-pages
+      - main
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/card-capture/next.config.mjs
+++ b/card-capture/next.config.mjs
@@ -2,6 +2,7 @@ import { withSentryConfig } from '@sentry/nextjs';
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  output: 'export',
   reactStrictMode: false,
   images: {
     domains: ['cardcaptureposterimage.s3.ap-northeast-2.amazonaws.com'],

--- a/card-capture/next.config.mjs
+++ b/card-capture/next.config.mjs
@@ -6,6 +6,7 @@ const nextConfig = {
   reactStrictMode: false,
   images: {
     domains: ['cardcaptureposterimage.s3.ap-northeast-2.amazonaws.com'],
+    unoptimized: true,
   },
 };
 

--- a/card-capture/src/app/auth/google/redirect/page.tsx
+++ b/card-capture/src/app/auth/google/redirect/page.tsx
@@ -1,3 +1,4 @@
+'use client';
 import GoogleAuthCallback from '@/components/common/Auth/GoogleAuthCallback';
 
 export default GoogleAuthCallback;

--- a/card-capture/src/app/editor/[templateId]/page.tsx
+++ b/card-capture/src/app/editor/[templateId]/page.tsx
@@ -1,5 +1,11 @@
 import dynamic from 'next/dynamic';
 
+export async function generateStaticParams() {
+  return Array.from({ length: 200 }, (_, i) => ({
+    templateId: i.toString(),
+  }));
+}
+
 const EditorPage = dynamic(() => import('@/app/editor/[templateId]/EditorContent'), {
   ssr: false,
   loading: () => <p></p>,

--- a/card-capture/src/app/prompt/result/[templateId]/page.tsx
+++ b/card-capture/src/app/prompt/result/[templateId]/page.tsx
@@ -1,5 +1,11 @@
 import dynamic from 'next/dynamic';
 
+export async function generateStaticParams() {
+  return Array.from({ length: 200 }, (_, i) => ({
+    templateId: i.toString(),
+  }));
+}
+
 const ResultPage = dynamic(() => import('./ResultContent'), {
   ssr: false,
   loading: () => <p></p>,

--- a/card-capture/src/app/templates/[templateId]/page.tsx
+++ b/card-capture/src/app/templates/[templateId]/page.tsx
@@ -1,5 +1,11 @@
 import dynamic from 'next/dynamic';
 
+export async function generateStaticParams() {
+  return Array.from({ length: 200 }, (_, i) => ({
+    templateId: i.toString(),
+  }));
+}
+
 const TemplatesPage = dynamic(() => import('./TemplatesContent'), {
   ssr: false,
   loading: () => <p></p>,


### PR DESCRIPTION
## 📝 설명
- github pages에 SSG 배포 시도

## 💡 관련 이슈
- X

## 📌 작업 내용

### 📍yml 파일 수정
- **환경변수 세팅**
  - 프로젝트 파일 경로가 root가 아니라 /card-capture 로 한 depth 더 들어가 있어서 **경로 불일치 문제 발생**
  - `github.workspace`의 default working directory는 `/home/runner/work/repository-name/repository-name`
      ➡️ 그래서 오류난 경로가  `/home/runner/work/card-capture-fe/card-catpure-fe` 
     <img width="1064" alt="스크린샷 2024-11-07 오후 6 35 42" src="https://github.com/user-attachments/assets/629d6afe-b6a7-4628-a19d-9ebc7adc8a41">
  - [ref: github actions docs](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/store-information-in-variables#default-environment-variables)
  <img width="725" alt="스크린샷 2024-11-07 오후 6 08 45" src="https://github.com/user-attachments/assets/ae3349e4-580d-4680-9271-f9632cd124dd">
   


- **경로 불일치 문제 해결 방법**
  - jobs에 환경변수 ./card-capure 경로 선언
  - jobs - defaults의 working-directory에 환경변수 설정해서 기본 워킹 디렉토리를 /card-capture로 설정

```
    env:
      WORKSPACE_PATH: ./card-capture

    defaults:
      run:
        shell: bash
        working-directory: ${{ env.WORKSPACE_PATH }}
```
```
#before
     elif [ -f "${{ github.workspace }}/package.json" ]; then
     cache-dependency-path: ./package-lock.json

#after
     elif [ -f "package.json" ]; then
     cache-dependency-path: ${{ env.WORKSPACE_PATH }}/package-lock.json
```

---

### 📍 SSG 렌더링을 위한 Config 설정
- 정적 파일 생성 허가를 위해 `'output: export'` 설정 - /out 파일에 정적 파일 생성됨
- 이미지 최적화 기능은 서버가 필요하기 때문에 최적화 기능 제거 `unoptimized: true`
```javascript
const nextConfig = {
  output: 'export',  // static HTML 생성을 위한 설정
  basePath: '/card-capture-fe',  // GitHub Pages용 base path
  images: {
    unoptimized: true,  // GitHub Pages 배포를 위해 필요
  },
}
```

### 📍 dynamic routing 사용하는 곳에 static routes 생성 
- Next에서 동적 경로 사용은 서버를 사용함
- 그래서 빌드 시점에서 정적인 경로를 설정하기 위해 generateStaticParams() 정의함
- 템플릿의 id를 기반으로 동적 경로를 생성하고 있는데 현재 id는 숫자값임 
  - 최대 id값을 알기 위해서는 서버에서 받아와야 하는데 확인하기 어려워서 기본적으로 200까지 생성
  - ⚠️ 정적 페이지를 200까지 다 만들어놓는 방식이라 효율적인 방식은 아니라고 생각 -> 어떻게 하는게 좋을지 고민 필요함!

```typescript
export async function generateStaticParams() {
  return Array.from({ length: 200 }, (_, i) => ({
    templateId: i.toString(),
  }));
}
```

